### PR TITLE
Don't shell out for NAR Export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,7 +2205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2919,7 +2919,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3587,7 +3587,7 @@ checksum = "d2628953ed836273ee4262e3708a8ef63ca38bd8a922070626eef7f9e5d8d536"
 [[package]]
 name = "nix-daemon"
 version = "0.1.1"
-source = "git+https://codeberg.org/blitz/gorgon.git?branch=nix-daemon#c38e149c305f2ab2e525722aced0c29eb72e7fd2"
+source = "git+https://codeberg.org/blitz/gorgon.git?branch=nix-daemon#e75e8d58d946c3eef54ec432dcecfd6248f7c617"
 dependencies = [
  "async-stream",
  "chrono",
@@ -3646,7 +3646,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4230,7 +4230,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.38",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4267,9 +4267,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4664,7 +4664,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5696,7 +5696,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6530,7 +6530,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -196,7 +196,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2205,7 +2205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3248,7 +3248,7 @@ dependencies = [
  "serde",
  "serde_json",
  "superboring",
- "thiserror 2.0.18",
+ "thiserror",
  "zeroize",
 ]
 
@@ -3587,7 +3587,7 @@ checksum = "d2628953ed836273ee4262e3708a8ef63ca38bd8a922070626eef7f9e5d8d536"
 [[package]]
 name = "nix-daemon"
 version = "0.1.1"
-source = "git+https://codeberg.org/blitz/gorgon.git?branch=nix-daemon#e75e8d58d946c3eef54ec432dcecfd6248f7c617"
+source = "git+https://codeberg.org/blitz/gorgon.git?branch=nix-daemon#7602b9749390305c18cd321c48670223e998481d"
 dependencies = [
  "async-stream",
  "chrono",
@@ -3595,9 +3595,9 @@ dependencies = [
  "num_enum",
  "serde",
  "serde_with",
- "strum 0.27.2",
+ "strum",
  "tap",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -3646,7 +3646,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4231,7 +4231,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.38",
  "socket2 0.5.10",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -4252,7 +4252,7 @@ dependencies = [
  "rustls 0.23.38",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4269,7 +4269,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4664,7 +4664,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4847,8 +4847,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum 0.28.0",
- "thiserror 2.0.18",
+ "strum",
+ "thiserror",
  "time",
  "tracing",
  "url",
@@ -4863,7 +4863,7 @@ checksum = "5c2eee8405f16c1f337fe3a83389361caea83c928d14dbd666a480407072c365"
 dependencies = [
  "arrow",
  "sea-query",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4942,7 +4942,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -5308,7 +5308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5399,7 +5399,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tokio",
  "tokio-stream",
@@ -5486,7 +5486,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tracing",
  "uuid",
@@ -5527,7 +5527,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tracing",
  "uuid",
@@ -5554,7 +5554,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tracing",
  "url",
@@ -5592,24 +5592,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
-name = "strum"
+name = "strum_macros"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5696,16 +5690,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5714,18 +5699,7 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Attic is:
 - ✅ Updated all dependencies.
 - ✅ Remove C++ bindings to `libnixstore`.
 - ✅ Simplified Nix and CI setup
-- 🚧 Use pure Rust code to talk to the Nix daemon. (Not completed.)
+- ✅ Use pure Rust code to talk to the Nix daemon.
 
 We are also interested in the following features and will work on them
 as time permits.

--- a/attic/benches/chunking.rs
+++ b/attic/benches/chunking.rs
@@ -1,5 +1,5 @@
-use std::io::Cursor;
 use std::hint::black_box;
+use std::io::Cursor;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use futures::StreamExt;

--- a/attic/src/error.rs
+++ b/attic/src/error.rs
@@ -14,6 +14,9 @@ pub enum AtticError {
     /// Failed to connect to the Nix store: {reason}
     StoreConnectError { reason: String },
 
+    /// Failed to get NAR from path: {reason}
+    NarFromPathError { reason: String },
+
     /// Invalid store path {path:?}: {reason}
     InvalidStorePath { path: PathBuf, reason: &'static str },
 
@@ -43,6 +46,7 @@ impl AtticError {
     pub fn name(&self) -> &'static str {
         match self {
             Self::StoreConnectError { .. } => "StoreConnectError",
+            Self::NarFromPathError { .. } => "NarFromPathError",
             Self::InvalidStorePath { .. } => "InvalidStorePath",
             Self::InvalidStorePathName { .. } => "InvalidStorePathName",
             Self::InvalidStorePathHash { .. } => "InvalidStorePathHash",

--- a/attic/src/nix_store/nix_store.rs
+++ b/attic/src/nix_store/nix_store.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
 use std::sync::Arc;
 
-use futures::{Stream, StreamExt, stream};
+use futures::{stream, Stream, StreamExt};
 use nix_daemon::{Progress, Store};
 use tokio::net::UnixStream;
 use tokio::sync::Mutex;
@@ -29,7 +29,9 @@ async fn daemon_connect() -> AtticResult<nix_daemon::nix::DaemonStore<UnixStream
     let daemon = nix_daemon::nix::DaemonStore::builder()
         .connect_unix(DAEMON_SOCKET_PATH)
         .await
-        .map_err(|e| AtticError::StoreConnectError { reason: e.to_string() })?;
+        .map_err(|e| AtticError::StoreConnectError {
+            reason: e.to_string(),
+        })?;
     Ok(daemon)
 }
 
@@ -118,12 +120,20 @@ impl NixStore {
             Ok::<_, AtticError>(daemon.nar_from_path(full_store_path_str))
         };
 
-        Box::pin(stream::once(setup_fn).then(async |s| {
-            match s {
-                Ok(stream) => stream.then(async |i| i.map_err(|e| AtticError::NarFromPathError { reason: e.to_string() })).left_stream(),
-                Err(e) => stream::once(async move { Err(e) }).right_stream(),
-            }
-        }).flatten())
+        Box::pin(
+            stream::once(setup_fn)
+                .then(async |s| match s {
+                    Ok(stream) => stream
+                        .then(async |i| {
+                            i.map_err(|e| AtticError::NarFromPathError {
+                                reason: e.to_string(),
+                            })
+                        })
+                        .left_stream(),
+                    Err(e) => stream::once(async move { Err(e) }).right_stream(),
+                })
+                .flatten(),
+        )
     }
 
     /// Returns the closure of a valid path.
@@ -161,13 +171,12 @@ impl NixStore {
                 // order.
                 result.insert(unqueried_path.clone());
 
-                let path_info = self
-                    .query_path_info(&unqueried_path)
-                    .await?
-                    .ok_or(AtticError::InvalidStorePath {
+                let path_info = self.query_path_info(&unqueried_path).await?.ok_or(
+                    AtticError::InvalidStorePath {
                         path: unqueried_path.base_name,
                         reason: "Missing reference",
-                    })?;
+                    },
+                )?;
 
                 unqueried_paths.extend_from_slice(&path_info.references);
             }

--- a/attic/src/nix_store/nix_store.rs
+++ b/attic/src/nix_store/nix_store.rs
@@ -2,16 +2,12 @@
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 use std::str::FromStr as _;
 use std::sync::Arc;
 
-use async_stream::try_stream;
-use futures::Stream;
+use futures::{Stream, StreamExt, stream};
 use nix_daemon::{Progress, Store};
-use tokio::io::AsyncReadExt;
 use tokio::net::UnixStream;
-use tokio::process::Command;
 use tokio::sync::Mutex;
 
 use super::{to_base_name, StorePath, ValidPathInfo};
@@ -27,17 +23,20 @@ pub struct NixStore {
     store_dir: PathBuf,
 }
 
+const DAEMON_SOCKET_PATH: &str = "/nix/var/nix/daemon-socket/socket";
+
+async fn daemon_connect() -> AtticResult<nix_daemon::nix::DaemonStore<UnixStream>> {
+    let daemon = nix_daemon::nix::DaemonStore::builder()
+        .connect_unix(DAEMON_SOCKET_PATH)
+        .await
+        .map_err(|e| AtticError::StoreConnectError { reason: e.to_string() })?;
+    Ok(daemon)
+}
+
 impl NixStore {
     pub async fn connect() -> AtticResult<Self> {
         Ok(Self {
-            daemon: Arc::new(Mutex::new(
-                nix_daemon::nix::DaemonStore::builder()
-                    .connect_unix("/nix/var/nix/daemon-socket/socket")
-                    .await
-                    .map_err(|e| AtticError::StoreConnectError {
-                        reason: e.to_string(),
-                    })?,
-            )),
+            daemon: Arc::new(Mutex::new(daemon_connect().await?)),
             // TODO: Make this method async and call nix-instantiate --raw --eval -E 'builtins.storeDir'
             store_dir: PathBuf::from_str("/nix/store").unwrap(),
         })
@@ -100,36 +99,31 @@ impl NixStore {
         &self,
         store_path: impl AsRef<StorePath>,
     ) -> impl Stream<Item = AtticResult<Vec<u8>>> + Unpin + Send {
-        let full_path = self.get_full_path(store_path);
-        Box::pin(try_stream! {
-            let mut child = Command::new("nix-store")
-                .arg("--dump")
-                .arg("--")
-                .arg(&full_path)
-                .stdout(Stdio::piped())
-                .stderr(Stdio::null())
-                .spawn()?;
+        let full_store_path = self.get_full_path(store_path);
+        let full_store_path_str = full_store_path
+            .to_str()
+            // TODO Move UTF-8 check to StorePath creation.
+            .unwrap()
+            .to_owned();
 
-            let mut stdout = child.stdout.take().expect("stdout is piped");
+        // We create a new store connection, because the
+        // implementation of daemon.nar_from_path is fragile.
+        //
+        // We also want to stream multiple NARs at the same time,
+        // which wouldn't work if we keep holding the daemon
+        // connection mutex.
+        let setup_fn = async move {
+            let daemon = daemon_connect().await?;
 
-            // This size is arbitrary. We read in "large enough" chunks.
-            let mut buf = vec![0u8; 16 << 20];
+            Ok::<_, AtticError>(daemon.nar_from_path(full_store_path_str))
+        };
 
-            loop {
-                let n = stdout.read(&mut buf).await?;
-                if n == 0 {
-                    break;
-                }
-                yield buf[..n].to_vec();
+        Box::pin(stream::once(setup_fn).then(async |s| {
+            match s {
+                Ok(stream) => stream.then(async |i| i.map_err(|e| AtticError::NarFromPathError { reason: e.to_string() })).left_stream(),
+                Err(e) => stream::once(async move { Err(e) }).right_stream(),
             }
-
-            let status = child.wait().await?;
-            if !status.success() {
-                Err(std::io::Error::other(
-                    format!("nix-store --dump exited with {status}"),
-                ))?;
-            }
-        })
+        }).flatten())
     }
 
     /// Returns the closure of a valid path.

--- a/attic/src/signing/mod.rs
+++ b/attic/src/signing/mod.rs
@@ -29,7 +29,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, DecodeError, 
 use displaydoc::Display;
 use ed25519_compact::{Error as SignatureError, KeyPair, PublicKey, Signature};
 
-use crate::{AtticError, error::AtticResult};
+use crate::{error::AtticResult, AtticError};
 
 #[cfg(test)]
 mod tests;

--- a/client/src/api/mod.rs
+++ b/client/src/api/mod.rs
@@ -176,8 +176,8 @@ impl ApiClient {
         force_preamble: bool,
     ) -> Result<Option<UploadPathResult>>
     where
-        S: TryStream<Ok = Bytes> + Send + Sync + 'static,
-        S::Error: Into<Box<dyn StdError + Send + Sync>> + Send + Sync,
+        S: TryStream<Ok = Bytes> + Send + 'static,
+        S::Error: Into<Box<dyn StdError + Send + Sync>> + Send,
     {
         let endpoint = self.endpoint.join("_api/v1/upload-path")?;
         let upload_info_json = serde_json::to_string(&nar_info)?;

--- a/client/src/nix_config.rs
+++ b/client/src/nix_config.rs
@@ -56,11 +56,15 @@ enum Line {
 impl std::fmt::Display for NixConfig {
     /// Reserialize the configuration back to a string.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{}", self.lines
-            .iter()
-            .map(|l| l.to_string())
-            .collect::<Vec<_>>()
-            .join("\n"))
+        writeln!(
+            f,
+            "{}",
+            self.lines
+                .iter()
+                .map(|l| l.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
     }
 }
 
@@ -157,7 +161,10 @@ impl std::fmt::Display for Line {
                 comment,
             } => {
                 let cmt = comment.as_deref().unwrap_or("");
-                write!(f, "{whitespace_s}{key}{whitespace_l}={whitespace_r}{value}{cmt}")
+                write!(
+                    f,
+                    "{whitespace_s}{key}{whitespace_l}={whitespace_r}{value}{cmt}"
+                )
             }
         }
     }

--- a/client/src/push.rs
+++ b/client/src/push.rs
@@ -604,7 +604,11 @@ pub async fn upload_path(
                     let seconds = elapsed.as_secs_f64();
                     let speed = (path_info.nar_size as f64 / seconds) as u64;
 
-                    let mut s = format!("{}, {}/s", HumanBytes(path_info.nar_size), HumanBytes(speed));
+                    let mut s = format!(
+                        "{}, {}/s",
+                        HumanBytes(path_info.nar_size),
+                        HumanBytes(speed)
+                    );
 
                     if let Some(frac_deduplicated) = r.frac_deduplicated {
                         if frac_deduplicated > 0.01f64 {


### PR DESCRIPTION
So far we used [Gorgon](https://codeberg.org/gorgon/gorgon)'s [nix-daemon](https://crates.io/crates/nix-daemon) crate to communicate with the Nix daemon, **except** for NAR exporting. I've given implementing this a [shot](https://codeberg.org/gorgon/gorgon/pulls/61) and we're using it here to avoid shelling out to `nix-store`.