### PR TITLE
Implement support for pushing and serving build traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `CELLER_TOKEN` environment variable as an alternative to `celler login`, useful for CI and scripted use.
 - `celler push` now prints the total NAR size.
+- Build trace support, so Nix can substitute the outputs of content-addressed derivations. Requires Nix 2.35 or newer on the client. Older Nix and Lix use a different scheme and cannot substitute.
 
 ### Changed
 

--- a/attic/src/api/v1/build_trace.rs
+++ b/attic/src/api/v1/build_trace.rs
@@ -1,0 +1,69 @@
+//! build-trace v2
+//!
+//! `GET`/`PUT` `/:cache/build-trace-v2/{drvName}.drv/{outputName}.doi`
+//!
+//! Reading requires "pull" permission, writing requires "push". Nix defines
+//! the path layout and the JSON body, so the names below are fixed.
+//!
+//! Nix 2.35 introduced this layout. The manual covers the concept and the
+//! entry, but not the URL, which only appears in the source.
+//!
+//! Concept: <https://releases.nixos.org/nix/nix-2.35.2/manual/store/build-trace.html>
+//!
+//! Entry: <https://releases.nixos.org/nix/nix-2.35.2/manual/protocols/json/build-trace-entry.html>
+//!
+//! Nix implementation of the URL: <https://github.com/NixOS/nix/blob/2c73b59da29606068c0c98db015dd3a66955525d/src/libstore/binary-cache-store.cc#L667-L670>
+//!
+//! Nix implementation of the prefix: <https://github.com/NixOS/nix/blob/2c73b59da29606068c0c98db015dd3a66955525d/src/libstore/include/nix/store/binary-cache-store.hh#L118>
+//!
+//! The C++ says "realisation" throughout, so the endpoint does not turn up
+//! under a search for "build trace".
+//!
+//! Nix writes the unkeyed half of the entry to the cache, since the path
+//! carries the key, which is why `BuildTraceEntry` has no `key` field.
+
+use serde::{Deserialize, Serialize};
+
+/// Path component introducing a build trace lookup.
+///
+/// Nix raises this version while the feature is experimental and abandons the
+/// entries at the old prefix.
+pub const BUILD_TRACE_PREFIX: &str = "build-trace-v2";
+
+/// Suffix on the output name in a build trace path.
+pub const BUILD_TRACE_SUFFIX: &str = ".doi";
+
+/// A build trace entry, as Nix reads and writes it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildTraceEntry {
+    /// Base name of the realized store path, without the store directory
+    /// prefix.
+    #[serde(rename = "outPath")]
+    pub out_path: String,
+
+    /// Signatures over the entry.
+    ///
+    /// Nix accepts an empty list.
+    #[serde(default)]
+    pub signatures: Vec<BuildTraceSignature>,
+}
+
+/// One signature over a build trace entry.
+///
+/// Neither Nix nor Celler verifies these when substituting, so both fields
+/// stay unparsed strings and any entry Nix accepts round-trips through here.
+///
+/// Nix implementation: <https://github.com/NixOS/nix/blob/2c73b59da29606068c0c98db015dd3a66955525d/src/libutil/include/nix/util/signature/local-keys.hh#L15-L22>
+///
+/// Nix issue on the missing check: <https://github.com/NixOS/nix/issues/11393>
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BuildTraceSignature {
+    /// Name of the key that produced `sig`.
+    ///
+    /// `NixKeypair::sign` returns this and `sig` joined by a colon.
+    #[serde(rename = "keyName")]
+    pub key_name: String,
+
+    /// Base64 of the raw signature bytes.
+    pub sig: String,
+}

--- a/attic/src/api/v1/mod.rs
+++ b/attic/src/api/v1/mod.rs
@@ -1,3 +1,4 @@
+pub mod build_trace;
 pub mod cache_config;
 pub mod get_missing_paths;
 pub mod upload_path;

--- a/attic/src/error.rs
+++ b/attic/src/error.rs
@@ -32,6 +32,9 @@ pub enum AtticError {
     /// Invalid cache name "{name}"
     InvalidCacheName { name: String },
 
+    /// Nix daemon query "{op}" failed: {reason}
+    DaemonQueryError { op: &'static str, reason: String },
+
     /// Signing error: {0}
     SigningError(super::signing::Error),
 
@@ -51,6 +54,7 @@ impl AtticError {
             Self::InvalidStorePathName { .. } => "InvalidStorePathName",
             Self::InvalidStorePathHash { .. } => "InvalidStorePathHash",
             Self::InvalidCacheName { .. } => "InvalidCacheName",
+            Self::DaemonQueryError { .. } => "DaemonQueryError",
             Self::SigningError(_) => "SigningError",
             Self::HashError(_) => "HashError",
             Self::IoError { .. } => "IoError",

--- a/attic/src/nix_store/mod.rs
+++ b/attic/src/nix_store/mod.rs
@@ -142,11 +142,37 @@ pub struct ValidPathInfo {
 
     /// Content Address.
     pub ca: Option<String>,
+
+    /// The derivation that produced this path, as a full path.
+    ///
+    /// A floating content-addressed output needs its deriver to get a build
+    /// trace, and the client skips any path whose deriver is `None` without
+    /// warning, so an empty field here means the path is pushed and then
+    /// rebuilt on every machine that pulls it.
+    ///
+    /// The daemon supplies this in its `QueryPathInfo` reply. Fetching it on
+    /// demand through `QueryValidDerivers` looks equivalent and is not,
+    /// because that query returns an empty list for a floating output even
+    /// while the output's `.drv` is valid in the store.
+    pub deriver: Option<String>,
+}
+
+/// A derivation output whose store path was not known before it was built.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FloatingOutput {
+    /// Base name of the derivation, including the `.drv` suffix.
+    pub drv_name: String,
+
+    /// Name of the output, such as `out` or `dev`.
+    pub output_name: String,
 }
 
 impl StorePath {
     /// Creates a StorePath with a base name.
-    fn from_base_name(base_name: impl AsRef<Path>) -> AtticResult<Self> {
+    ///
+    /// This validates the format, so it doubles as the check for a base name
+    /// that arrived from an untrusted source.
+    pub fn from_base_name(base_name: impl AsRef<Path>) -> AtticResult<Self> {
         let base_name = base_name.as_ref().to_owned();
         let s = base_name
             .as_os_str()

--- a/attic/src/nix_store/nix_store.rs
+++ b/attic/src/nix_store/nix_store.rs
@@ -1,6 +1,6 @@
 //! High-level Nix Store interface.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
 use std::sync::Arc;
@@ -12,7 +12,7 @@ use tokio::net::UnixStream;
 use tokio::sync::Mutex;
 use tokio_util::io::ReaderStream;
 
-use super::{to_base_name, StorePath, ValidPathInfo};
+use super::{to_base_name, FloatingOutput, StorePath, ValidPathInfo};
 use crate::error::AtticResult;
 use crate::hash::Hash;
 use crate::AtticError;
@@ -212,6 +212,107 @@ impl NixStore {
             .unwrap_or(false))
     }
 
+    /// Identifies the derivation output a path realized to, if it was floating.
+    ///
+    /// Returns `None` when the path is not floating, or when its deriver is gone
+    /// and the question cannot be answered.
+    pub async fn floating_output(
+        &self,
+        path: impl AsRef<StorePath>,
+        deriver: &str,
+    ) -> AtticResult<Option<FloatingOutput>> {
+        let path = path.as_ref();
+
+        // Only a floating output is absent from the derivation output table, so
+        // a deriver recorded there means the path was known ahead of the build.
+        //
+        // An empty result also covers a path whose deriver is gone, which the
+        // validity check below separates out. Keep the two checks in this
+        // order.
+        if !self.query_valid_derivers(path).await?.is_empty() {
+            return Ok(None);
+        }
+
+        // The deriver of a substituted path is generally not in the store,
+        // since `nix copy` does not transfer `.drv` files, and a built path can
+        // outlive its deriver.
+        let deriver_path = self.parse_store_path(deriver)?;
+        if !self.is_valid_path(&deriver_path).await? {
+            return Ok(None);
+        }
+
+        let drv_name = deriver_path
+            .as_os_str()
+            .to_str()
+            .ok_or_else(|| AtticError::InvalidStorePath {
+                path: deriver_path.base_name.clone(),
+                reason: "Invalid UTF-8",
+            })?
+            .to_owned();
+
+        let outputs = self.query_derivation_output_map(deriver).await?;
+        let output_name = outputs
+            .into_iter()
+            .find(|(_, out)| self.parse_store_path(out).ok().as_ref() == Some(path))
+            .map(|(output_name, _)| output_name)
+            .ok_or_else(|| AtticError::InvalidStorePath {
+                path: path.base_name.clone(),
+                reason: "Deriver has no output matching this path",
+            })?;
+
+        Ok(Some(FloatingOutput {
+            drv_name,
+            output_name,
+        }))
+    }
+
+    /// Returns the derivations in the store known to produce a path.
+    ///
+    /// Returns nothing for a floating content-addressed output.
+    pub async fn query_valid_derivers(
+        &self,
+        store_path: impl AsRef<StorePath>,
+    ) -> AtticResult<Vec<String>> {
+        let full_store_path = self.get_full_path(&store_path);
+        let full_store_path_str =
+            full_store_path
+                .to_str()
+                .ok_or_else(|| AtticError::InvalidStorePath {
+                    path: full_store_path.clone(),
+                    reason: "Invalid UTF-8",
+                })?;
+
+        let mut daemon = self.daemon.lock().await;
+        daemon
+            .query_valid_derivers(full_store_path_str)
+            .result()
+            .await
+            .map_err(|e| AtticError::DaemonQueryError {
+                op: "QueryValidDerivers",
+                reason: e.to_string(),
+            })
+    }
+
+    /// Maps each output of a derivation to the store path it realized to.
+    ///
+    /// For a content-addressed derivation the daemon answers from the local
+    /// build trace, so this only returns outputs that have been built on this
+    /// machine.
+    pub async fn query_derivation_output_map(
+        &self,
+        drv_path: &str,
+    ) -> AtticResult<HashMap<String, String>> {
+        let mut daemon = self.daemon.lock().await;
+        daemon
+            .query_derivation_output_map(drv_path)
+            .result()
+            .await
+            .map_err(|e| AtticError::DaemonQueryError {
+                op: "QueryDerivationOutputMap",
+                reason: e.to_string(),
+            })
+    }
+
     /// Returns detailed information on a path.
     pub async fn query_path_info(
         &self,
@@ -252,6 +353,7 @@ impl NixStore {
                         .collect::<AtticResult<Vec<_>>>()?,
                     sigs: path_info.signatures,
                     ca: path_info.ca,
+                    deriver: path_info.deriver,
                 })
             })
             .transpose()

--- a/client/src/api/mod.rs
+++ b/client/src/api/mod.rs
@@ -17,6 +17,7 @@ use serde::Deserialize;
 
 use crate::config::ServerConfig;
 use crate::version::CELLER_DISTRIBUTOR;
+use attic::api::v1::build_trace::{BuildTraceEntry, BUILD_TRACE_PREFIX, BUILD_TRACE_SUFFIX};
 use attic::api::v1::cache_config::{CacheConfig, CreateCacheRequest};
 use attic::api::v1::get_missing_paths::{GetMissingPathsRequest, GetMissingPathsResponse};
 use attic::api::v1::upload_path::{
@@ -162,6 +163,44 @@ impl ApiClient {
         if res.status().is_success() {
             let cache_config = res.json().await?;
             Ok(cache_config)
+        } else {
+            let api_error = ApiError::try_from_response(res).await?;
+            Err(api_error.into())
+        }
+    }
+
+    /// Records the store path that a derivation output realized to.
+    pub async fn put_build_trace(
+        &self,
+        cache: &CacheName,
+        drv_name: &str,
+        output_name: &str,
+        out_path: &str,
+    ) -> Result<()> {
+        // `?` is legal in a store path name, and interpolating one
+        // into the URL would turn the rest of the path into a query
+        // string, so this appends the segments one at a time instead.
+        let mut endpoint = self.endpoint.clone();
+        endpoint
+            .path_segments_mut()
+            .map_err(|_| anyhow::anyhow!("API endpoint cannot be a base"))?
+            .pop_if_empty()
+            .extend([
+                cache.as_str(),
+                BUILD_TRACE_PREFIX,
+                drv_name,
+                &format!("{output_name}{BUILD_TRACE_SUFFIX}"),
+            ]);
+
+        let payload = BuildTraceEntry {
+            out_path: out_path.to_owned(),
+            signatures: Vec::new(),
+        };
+
+        let res = self.client.put(endpoint).json(&payload).send().await?;
+
+        if res.status().is_success() {
+            Ok(())
         } else {
             let api_error = ApiError::try_from_response(res).await?;
             Err(api_error.into())

--- a/client/src/command/push.rs
+++ b/client/src/command/push.rs
@@ -101,7 +101,7 @@ impl PushContext {
             .plan(roots, self.no_closure, self.ignore_upstream_cache_filter)
             .await?;
 
-        if plan.store_path_map.is_empty() {
+        if plan.store_path_map.is_empty() && plan.traces_to_record.is_empty() {
             if plan.num_all_paths == 0 {
                 eprintln!("🤷 Nothing selected.");
             } else {
@@ -113,6 +113,14 @@ impl PushContext {
             }
 
             return Ok(());
+        }
+
+        if plan.store_path_map.is_empty() {
+            eprintln!(
+                "✅ All NARs cached ({num_already_cached} already cached, {num_upstream} in upstream), checking build traces...",
+                num_already_cached = plan.num_already_cached,
+                num_upstream = plan.num_upstream,
+            );
         } else {
             eprintln!("⚙️ Pushing {num_missing_paths} paths to \"{cache}\" on \"{server}\" ({num_already_cached} already cached, {num_upstream} in upstream)...",
                 cache = self.cache_name.as_str(),
@@ -125,6 +133,10 @@ impl PushContext {
 
         for (_, path_info) in plan.store_path_map {
             self.pusher.queue(path_info).await?;
+        }
+
+        for (path, deriver) in plan.traces_to_record {
+            self.pusher.queue_trace_only(path, deriver).await?;
         }
 
         let results = self.pusher.wait().await;

--- a/client/src/push.rs
+++ b/client/src/push.rs
@@ -40,8 +40,17 @@ use attic::error::AtticResult;
 use attic::nix_store::{NixStore, StorePath, StorePathHash, ValidPathInfo};
 use tracing::error;
 
-type JobSender = channel::Sender<ValidPathInfo>;
-type JobReceiver = channel::Receiver<ValidPathInfo>;
+type JobSender = channel::Sender<PushJob>;
+type JobReceiver = channel::Receiver<PushJob>;
+
+/// A unit of work for a push worker.
+enum PushJob {
+    /// Upload the NAR, then record a build trace if the path needs one.
+    Upload(ValidPathInfo),
+
+    /// Record only the build trace, for a path the cache already holds.
+    RecordTrace { path: StorePath, deriver: String },
+}
 
 /// Configuration for pushing store paths.
 #[derive(Clone, Copy, Debug)]
@@ -126,6 +135,11 @@ pub struct PushPlan {
     /// Store paths to push.
     pub store_path_map: HashMap<StorePathHash, ValidPathInfo>,
 
+    /// Cached paths whose build trace still needs recording.
+    ///
+    /// A cache can hold the NAR while the trace is still missing.
+    pub traces_to_record: Vec<(StorePath, String)>,
+
     /// The number of paths in the original full closure.
     pub num_all_paths: usize,
 
@@ -177,7 +191,19 @@ impl Pusher {
 
     /// Queues a store path to be pushed.
     pub async fn queue(&self, path_info: ValidPathInfo) -> Result<()> {
-        self.sender.send(path_info).await.map_err(|e| anyhow!(e))
+        self.send(PushJob::Upload(path_info)).await
+    }
+
+    /// Queues a path for build-trace recording only.
+    ///
+    /// The push plan skips paths the cache already holds, so they would
+    /// otherwise never get a trace.
+    pub async fn queue_trace_only(&self, path: StorePath, deriver: String) -> Result<()> {
+        self.send(PushJob::RecordTrace { path, deriver }).await
+    }
+
+    async fn send(&self, job: PushJob) -> Result<()> {
+        self.sender.send(job).await.map_err(|e| anyhow!(e))
     }
 
     /// Waits for all workers to terminate, returning all results.
@@ -237,25 +263,34 @@ impl Pusher {
         let mut results = HashMap::new();
 
         loop {
-            let path_info = match receiver.recv().await {
-                Ok(path_info) => path_info,
+            let job = match receiver.recv().await {
+                Ok(job) => job,
                 Err(_) => {
                     // channel is closed - we are done
                     break;
                 }
             };
 
-            let store_path = path_info.path.clone();
-
-            let r = upload_path(
-                path_info,
-                store.clone(),
-                api.clone(),
-                &cache,
-                mp.clone(),
-                config.force_preamble,
-            )
-            .await;
+            let (store_path, r) = match job {
+                PushJob::Upload(path_info) => {
+                    let store_path = path_info.path.clone();
+                    let r = upload_path(
+                        path_info,
+                        store.clone(),
+                        api.clone(),
+                        &cache,
+                        mp.clone(),
+                        config.force_preamble,
+                    )
+                    .await;
+                    (store_path, r)
+                }
+                // A trace failure only warns, so this arm is always `Ok`.
+                PushJob::RecordTrace { path, deriver } => {
+                    record_build_trace_or_warn(&path, &deriver, &store, &api, &cache, &mp).await;
+                    (path, Ok(()))
+                }
+            };
 
             results.insert(store_path, r);
         }
@@ -358,6 +393,10 @@ impl PushSession {
             let mut known_paths = known_paths_mutex.lock().await;
             plan.store_path_map
                 .retain(|sph, _| !known_paths.contains(sph));
+            // A batch recomputes the plan from scratch, so without this every
+            // already-cached path is re-queued on every batch, forever.
+            plan.traces_to_record
+                .retain(|(path, _)| !known_paths.contains(&path.to_hash()));
 
             // Push everything
             for (store_path_hash, path_info) in plan.store_path_map.into_iter() {
@@ -365,6 +404,15 @@ impl PushSession {
                     .queue(path_info)
                     .await
                     .context("Failed to queue path for upload")?;
+                known_paths.insert(store_path_hash);
+            }
+
+            for (path, deriver) in plan.traces_to_record {
+                let store_path_hash = path.to_hash();
+                pusher
+                    .queue_trace_only(path, deriver)
+                    .await
+                    .context("Failed to queue path for build trace recording")?;
                 known_paths.insert(store_path_hash);
             }
 
@@ -463,6 +511,7 @@ impl PushPlan {
         if store_path_map.is_empty() {
             return Ok(Self {
                 store_path_map,
+                traces_to_record: Vec::new(),
                 num_all_paths,
                 num_already_cached: 0,
                 num_upstream: 0,
@@ -492,6 +541,7 @@ impl PushPlan {
         if store_path_map.is_empty() {
             return Ok(Self {
                 store_path_map,
+                traces_to_record: Vec::new(),
                 num_all_paths,
                 num_already_cached: 0,
                 num_upstream: num_all_paths - num_filtered_paths,
@@ -504,11 +554,27 @@ impl PushPlan {
             let res = api.get_missing_paths(cache, store_path_hashes).await?;
             res.missing_paths.into_iter().collect()
         };
-        store_path_map.retain(|sph, _| missing_path_hashes.contains(sph));
+        // A trace is a separate fact from the NAR, so an already-cached path
+        // may still be missing one.
+        let (missing, already_cached): (HashMap<_, _>, HashMap<_, _>) = store_path_map
+            .into_iter()
+            .partition(|(sph, _)| missing_path_hashes.contains(sph));
+
+        store_path_map = missing;
+
+        // This drops every path without a content address or a deriver, so a
+        // caller can queue each remaining entry without checking again.
+        let traces_to_record = already_cached
+            .into_values()
+            .filter(|pi| pi.ca.is_some())
+            .filter_map(|pi| Some((pi.path, pi.deriver?)))
+            .collect();
+
         let num_missing_paths = store_path_map.len();
 
         Ok(Self {
             store_path_map,
+            traces_to_record,
             num_all_paths,
             num_already_cached: num_filtered_paths - num_missing_paths,
             num_upstream: num_all_paths - num_filtered_paths,
@@ -526,6 +592,8 @@ pub async fn upload_path(
     force_preamble: bool,
 ) -> Result<()> {
     let path = &path_info.path;
+    let is_content_addressed = path_info.ca.is_some();
+    let deriver = path_info.deriver.clone();
     let upload_info = {
         let full_path = store
             .get_full_path(path)
@@ -626,7 +694,14 @@ pub async fn upload_path(
                     info_string
                 );
             });
+
             bar.finish_and_clear();
+
+            if is_content_addressed {
+                if let Some(deriver) = deriver.as_deref() {
+                    record_build_trace_or_warn(path, deriver, &store, &api, cache, &mp).await;
+                }
+            }
 
             Ok(())
         }
@@ -638,6 +713,49 @@ pub async fn upload_path(
             Err(e)
         }
     }
+}
+
+/// Records a path's build trace, reporting a failure as a warning.
+async fn record_build_trace_or_warn(
+    path: &StorePath,
+    deriver: &str,
+    store: &NixStore,
+    api: &ApiClient,
+    cache: &CacheName,
+    mp: &MultiProgress,
+) {
+    if let Err(e) = upload_build_trace(path, deriver, store, api, cache).await {
+        mp.suspend(|| {
+            eprintln!(
+                "⚠️ {}: failed to record build trace: {}",
+                path.as_os_str().to_string_lossy(),
+                e
+            );
+        });
+    }
+}
+
+/// Records the build trace covering a content-addressed path.
+async fn upload_build_trace(
+    path: &StorePath,
+    deriver: &str,
+    store: &NixStore,
+    api: &ApiClient,
+    cache: &CacheName,
+) -> Result<()> {
+    let base_name = path
+        .as_os_str()
+        .to_str()
+        .ok_or_else(|| anyhow!("Path contains non-UTF-8"))?;
+
+    // `ca` is set for fixed-output derivations too, and only the store can
+    // tell those from a floating output.
+    let Some(output) = store.floating_output(path, deriver).await? else {
+        return Ok(());
+    };
+
+    api.put_build_trace(cache, &output.drv_name, &output.output_name, base_name)
+        .await
 }
 
 impl<S: Stream<Item = AtticResult<Bytes>>> NarStreamProgress<S> {

--- a/server/src/api/binary_cache.rs
+++ b/server/src/api/binary_cache.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use axum::http;
 use axum::{
     body::Body,
-    extract::{Extension, Path},
+    extract::{Extension, Json, Path},
     http::StatusCode,
     response::{IntoResponse, Redirect, Response},
     routing::get,
@@ -24,13 +24,17 @@ use serde::Serialize;
 use tokio_util::io::ReaderStream;
 use tracing::instrument;
 
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+use crate::database::entity::build_trace::{self, Entity as BuildTrace};
 use crate::database::entity::chunk::ChunkModel;
 use crate::database::AtticDatabase;
-use crate::error::{ErrorKind, ServerResult};
+use crate::error::{ErrorKind, ServerError, ServerResult};
 use crate::narinfo::NarInfo;
 use crate::nix_manifest;
 use crate::storage::{Download, StorageBackend};
 use crate::{RequestState, State};
+use attic::api::v1::build_trace::{BuildTraceEntry, BUILD_TRACE_PREFIX, BUILD_TRACE_SUFFIX};
 use attic::cache::CacheName;
 use attic::io::merge_chunks;
 use attic::mime;
@@ -279,9 +283,76 @@ async fn get_nar(
     }
 }
 
+/// Resolves a derivation output to its realized store path.
+///
+/// - GET `/:cache/build-trace-v2/{drvName}.drv/{outputName}.doi`
+#[instrument(skip_all, fields(cache_name, drv_path, output))]
+async fn get_build_trace(
+    Extension(state): Extension<State>,
+    Extension(req_state): Extension<RequestState>,
+    Path((cache_name, drv_path, output)): Path<(CacheName, String, String)>,
+) -> ServerResult<Json<BuildTraceEntry>> {
+    let output_name = output
+        .strip_suffix(BUILD_TRACE_SUFFIX)
+        .ok_or_else(|| ServerError::from(ErrorKind::NotFound))?;
+
+    let database = state.database().await?;
+    let cache = req_state
+        .auth
+        .auth_cache(database, &cache_name, |cache, permission| {
+            permission.require_pull()?;
+            Ok(cache)
+        })
+        .await?;
+
+    req_state.set_public_cache(cache.is_public);
+
+    tracing::debug!(
+        "Received build trace request for {}!{} in {:?}",
+        drv_path,
+        output_name,
+        cache_name
+    );
+
+    let entry = BuildTrace::find()
+        .filter(build_trace::Column::CacheId.eq(cache.id))
+        .filter(build_trace::Column::DrvPath.eq(drv_path))
+        .filter(build_trace::Column::OutputName.eq(output_name))
+        .one(database)
+        .await
+        .map_err(ServerError::database_error)?
+        .ok_or_else(|| ServerError::from(ErrorKind::NoSuchObject))?;
+
+    // This handler repeats the object lookup the upload already did, because a
+    // trace outlives the object a GC reaps. Serving such a trace makes this
+    // cache assert a store path it holds no NAR for, and the client may then
+    // fetch that path from some other cache.
+    let out_path_hash = StorePathHash::new(entry.out_path_hash)
+        .map_err(|_| ServerError::from(ErrorKind::NoSuchObject))?;
+    let object = database
+        .find_object_by_store_path_hash(cache.id, &out_path_hash)
+        .await?;
+
+    // The name has to match as well, because an object upsert can change
+    // `store_path` under a fixed hash, which leaves the trace naming a path
+    // this cache no longer claims.
+    if object.store_path_base_name() != Some(entry.out_path.as_str()) {
+        return Err(ErrorKind::NoSuchObject.into());
+    }
+
+    Ok(Json(BuildTraceEntry {
+        out_path: entry.out_path,
+        signatures: entry.signatures.0,
+    }))
+}
+
 pub fn get_router() -> Router {
     Router::new()
         .route("/{cache}/nix-cache-info", get(get_nix_cache_info))
         .route("/{cache}/{path}", get(get_store_path_info))
         .route("/{cache}/nar/{path}", get(get_nar))
+        .route(
+            &format!("/{{cache}}/{BUILD_TRACE_PREFIX}/{{drv_path}}/{{output}}"),
+            get(get_build_trace),
+        )
 }

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -15,3 +15,15 @@ pub(crate) fn get_router() -> Router {
         .merge(binary_cache::get_router())
         .merge(v1::get_router())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Axum panics on conflicting routes when it builds the router, and
+    /// without this test that panic would only show up at server startup.
+    #[test]
+    fn router_builds() {
+        let _ = get_router();
+    }
+}

--- a/server/src/api/v1/build_trace.rs
+++ b/server/src/api/v1/build_trace.rs
@@ -1,0 +1,145 @@
+//! Build trace upload.
+
+use anyhow::anyhow;
+use axum::extract::{Extension, Json, Path};
+use chrono::Utc;
+use sea_orm::sea_query::{Expr, OnConflict, Query};
+use sea_orm::{ColumnTrait, ConnectionTrait};
+use tracing::instrument;
+
+use crate::database::entity::build_trace::{self, Entity as BuildTrace};
+use crate::database::entity::object;
+use crate::database::entity::Json as DbJson;
+use crate::database::AtticDatabase;
+use crate::error::{ErrorKind, ServerError, ServerResult};
+use crate::{RequestState, State};
+use attic::api::v1::build_trace::{BuildTraceEntry, BUILD_TRACE_SUFFIX};
+use attic::cache::CacheName;
+use attic::nix_store::StorePath;
+
+/// Must match the column widths in the `build_trace` migration.
+const MAX_DRV_PATH_LEN: usize = 255;
+const MAX_OUTPUT_NAME_LEN: usize = 128;
+const MAX_OUT_PATH_LEN: usize = 255;
+
+/// Records the store path that a derivation output realized to.
+///
+/// - PUT `/:cache/build-trace-v2/{drvName}.drv/{outputName}.doi`
+#[instrument(skip_all, fields(cache_name, drv_path, output))]
+pub(crate) async fn put_build_trace(
+    Extension(state): Extension<State>,
+    Extension(req_state): Extension<RequestState>,
+    Path((cache_name, drv_path, output)): Path<(CacheName, String, String)>,
+    Json(payload): Json<BuildTraceEntry>,
+) -> ServerResult<()> {
+    let output_name = output
+        .strip_suffix(BUILD_TRACE_SUFFIX)
+        .ok_or_else(|| ServerError::from(ErrorKind::NotFound))?;
+
+    let database = state.database().await?;
+    let cache = req_state
+        .auth
+        .auth_cache(database, &cache_name, |cache, permission| {
+            permission.require_push()?;
+            Ok(cache)
+        })
+        .await?;
+
+    tracing::debug!(
+        "Storing build trace for {}!{} in {:?}",
+        drv_path,
+        output_name,
+        cache_name
+    );
+
+    // SQLite ignores varchar lengths, and PostgreSQL would answer 500 instead.
+    if drv_path.len() > MAX_DRV_PATH_LEN
+        || output_name.len() > MAX_OUTPUT_NAME_LEN
+        || payload.out_path.len() > MAX_OUT_PATH_LEN
+    {
+        return Err(ErrorKind::RequestError(anyhow!("Build trace entry too long")).into());
+    }
+
+    // Nix turns an unparseable path into a build failure.
+    let out_path =
+        StorePath::from_base_name(&payload.out_path).map_err(ServerError::request_error)?;
+    let out_path_hash = out_path.to_hash();
+
+    // The object lookup keeps the binding inside the tenant, because a cache
+    // holding no objects could otherwise assert a path that a client then
+    // fetches from some other cache.
+    let object = database
+        .find_object_by_store_path_hash(cache.id, &out_path_hash)
+        .await?;
+
+    if object.store_path_base_name() != Some(payload.out_path.as_str()) {
+        return Err(ErrorKind::RequestError(anyhow!(
+            "outPath does not match the store path recorded for that hash"
+        ))
+        .into());
+    }
+
+    // The insert selects its row from `object`, so a GC that reaps the object
+    // between the lookup and the write leaves no row to insert. That repeats
+    // the check above at the moment of the write.
+    //
+    // These expressions must stay in lockstep with the column list below.
+    let source = Query::select()
+        .expr(Expr::val(cache.id))
+        .expr(Expr::val(drv_path))
+        .expr(Expr::val(output_name.to_owned()))
+        .expr(Expr::val(payload.out_path))
+        .expr(Expr::val(out_path_hash.as_str().to_owned()))
+        .expr(Expr::val(DbJson(payload.signatures)))
+        .expr(Expr::val(Utc::now()))
+        .expr(Expr::val(req_state.auth.username().map(str::to_string)))
+        .from(object::Entity)
+        .and_where(object::Column::CacheId.eq(cache.id))
+        .and_where(object::Column::StorePathHash.eq(out_path_hash.as_str()))
+        .to_owned();
+
+    let mut insert = Query::insert();
+    insert.into_table(BuildTrace).columns([
+        build_trace::Column::CacheId,
+        build_trace::Column::DrvPath,
+        build_trace::Column::OutputName,
+        build_trace::Column::OutPath,
+        build_trace::Column::OutPathHash,
+        build_trace::Column::Signatures,
+        build_trace::Column::CreatedAt,
+        build_trace::Column::CreatedBy,
+    ]);
+    insert
+        .select_from(source)
+        // `select_from` only fails when the column count differs from the
+        // number of expressions above.
+        .map_err(ServerError::database_error)?
+        .on_conflict(
+            OnConflict::columns([
+                build_trace::Column::CacheId,
+                build_trace::Column::DrvPath,
+                build_trace::Column::OutputName,
+            ])
+            // `CreatedAt` stays out of the update, so the column keeps the
+            // creation time that age-based cleanup reads.
+            .update_columns([
+                build_trace::Column::OutPath,
+                build_trace::Column::OutPathHash,
+                build_trace::Column::Signatures,
+                build_trace::Column::CreatedBy,
+            ])
+            .to_owned(),
+        );
+
+    let insertion = database
+        .execute(&insert)
+        .await
+        .map_err(ServerError::database_error)?;
+
+    if insertion.rows_affected() == 0 {
+        // A GC reaped the object between the lookup and the insert.
+        return Err(ErrorKind::NoSuchObject.into());
+    }
+
+    Ok(())
+}

--- a/server/src/api/v1/mod.rs
+++ b/server/src/api/v1/mod.rs
@@ -1,3 +1,4 @@
+mod build_trace;
 mod cache_config;
 mod get_missing_paths;
 mod upload_path;
@@ -7,6 +8,8 @@ use axum::{
     Router,
 };
 
+use attic::api::v1::build_trace::BUILD_TRACE_PREFIX;
+
 pub(crate) fn get_router() -> Router {
     Router::new()
         .route(
@@ -14,6 +17,10 @@ pub(crate) fn get_router() -> Router {
             post(get_missing_paths::get_missing_paths),
         )
         .route("/_api/v1/upload-path", put(upload_path::upload_path))
+        .route(
+            &format!("/{{cache}}/{BUILD_TRACE_PREFIX}/{{drv_path}}/{{output}}"),
+            put(build_trace::put_build_trace),
+        )
         .route(
             "/{cache}/attic-cache-info",
             get(cache_config::get_cache_config),

--- a/server/src/database/entity/build_trace.rs
+++ b/server/src/database/entity/build_trace.rs
@@ -1,0 +1,74 @@
+//! A build trace entry.
+
+use sea_orm::entity::prelude::*;
+
+use super::Json;
+use attic::api::v1::build_trace::BuildTraceSignature;
+
+pub type BuildTraceModel = Model;
+
+/// A mapping from a derivation output to its realized store path.
+#[derive(Debug, Clone, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "build_trace")]
+pub struct Model {
+    /// Unique numeric ID of the entry.
+    #[sea_orm(primary_key)]
+    pub id: i64,
+
+    /// ID of the cache the entry belongs to.
+    #[sea_orm(indexed)]
+    pub cache_id: i64,
+
+    /// Base name of the producing derivation.
+    ///
+    /// For example `<hash>-hello.drv`. Nix looks the output up by the resolved
+    /// derivation, so that is what this column holds.
+    #[sea_orm(column_type = "String(StringLen::N(255))", indexed)]
+    pub drv_path: String,
+
+    /// Name of the derivation output, such as `out` or `dev`.
+    #[sea_orm(column_type = "String(StringLen::N(128))")]
+    pub output_name: String,
+
+    /// Base name of the realized store path.
+    #[sea_orm(column_type = "String(StringLen::N(255))")]
+    pub out_path: String,
+
+    /// The hash portion of `out_path`.
+    ///
+    /// Denormalized so joins against the object table need no backend-specific
+    /// substring expression. Those joins drive off the object table's index.
+    #[sea_orm(column_type = "String(StringLen::N(32))")]
+    pub out_path_hash: String,
+
+    /// Signatures over the entry.
+    ///
+    /// Because Nix does not yet verify these when substituting, this will be empty.
+    pub signatures: Json<Vec<BuildTraceSignature>>,
+
+    /// Timestamp of entry creation.
+    pub created_at: ChronoDateTimeUtc,
+
+    /// The uploader of the entry.
+    ///
+    /// This is a "username", set to the `sub` claim in the client's JWT.
+    pub created_by: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::cache::Entity",
+        from = "Column::CacheId",
+        to = "super::cache::Column::Id"
+    )]
+    Cache,
+}
+
+impl Related<super::cache::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Cache.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/server/src/database/entity/mod.rs
+++ b/server/src/database/entity/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! We use SeaORM and target PostgreSQL (production) and SQLite (development).
 
+pub mod build_trace;
 pub mod cache;
 pub mod chunk;
 pub mod chunkref;

--- a/server/src/database/entity/object.rs
+++ b/server/src/database/entity/object.rs
@@ -2,7 +2,7 @@
 //!
 //! It's backed by a NAR in the global cache.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use sea_orm::entity::prelude::*;
@@ -115,6 +115,16 @@ impl InsertExt for Insert<ActiveModel> {
 }
 
 impl Model {
+    /// Returns the base name of the store path this object caches.
+    ///
+    /// `store_path` is the full path, as supplied by the client that uploaded
+    /// it, so this can be `None` for a stored value that is not a path.
+    pub fn store_path_base_name(&self) -> Option<&str> {
+        Path::new(&self.store_path)
+            .file_name()
+            .and_then(|n| n.to_str())
+    }
+
     /// Converts this object to a NarInfo.
     pub fn to_nar_info(&self, nar: &NarModel) -> ServerResult<NarInfo> {
         let nar_size = nar

--- a/server/src/database/migration/m20260817_000001_add_build_trace_table.rs
+++ b/server/src/database/migration/m20260817_000001_add_build_trace_table.rs
@@ -1,0 +1,78 @@
+use sea_orm_migration::prelude::*;
+
+use crate::database::entity::build_trace::*;
+use crate::database::entity::cache;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260817_000001_add_build_trace_table"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Entity)
+                    .col(
+                        ColumnDef::new(Column::Id)
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Column::CacheId).big_integer().not_null())
+                    // Bounded because PostgreSQL caps a btree index tuple at
+                    // 2704 bytes.
+                    .col(ColumnDef::new(Column::DrvPath).string_len(255).not_null())
+                    .col(
+                        ColumnDef::new(Column::OutputName)
+                            .string_len(128)
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(Column::OutPath).string_len(255).not_null())
+                    .col(
+                        ColumnDef::new(Column::OutPathHash)
+                            .string_len(32)
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(Column::Signatures).string().not_null())
+                    .col(
+                        ColumnDef::new(Column::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(Column::CreatedBy).string())
+                    .foreign_key(
+                        ForeignKeyCreateStatement::new()
+                            .name("fk_build_trace_cache")
+                            .from_tbl(Entity)
+                            .from_col(Column::CacheId)
+                            .to_tbl(cache::Entity)
+                            .to_col(cache::Column::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Unique because a derivation output resolves to exactly one store path
+        // per cache.
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-build-trace-lookup")
+                    .table(Entity)
+                    .col(Column::CacheId)
+                    .col(Column::DrvPath)
+                    .col(Column::OutputName)
+                    .unique()
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/server/src/database/migration/mod.rs
+++ b/server/src/database/migration/mod.rs
@@ -14,6 +14,7 @@ mod m20230112_000003_add_nar_num_chunks;
 mod m20230112_000004_migrate_nar_remote_files_to_chunks;
 mod m20230112_000005_drop_old_nar_columns;
 mod m20230112_000006_add_nar_completeness_hint;
+mod m20260817_000001_add_build_trace_table;
 
 pub struct Migrator;
 
@@ -33,6 +34,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230112_000004_migrate_nar_remote_files_to_chunks::Migration),
             Box::new(m20230112_000005_drop_old_nar_columns::Migration),
             Box::new(m20230112_000006_add_nar_completeness_hint::Migration),
+            Box::new(m20260817_000001_add_build_trace_table::Migration),
         ]
     }
 }

--- a/server/src/database/mod.rs
+++ b/server/src/database/mod.rs
@@ -42,6 +42,17 @@ pub trait AtticDatabase: Send + Sync {
         include_chunks: bool,
     ) -> ServerResult<(ObjectModel, CacheModel, NarModel, Vec<Option<ChunkModel>>)>;
 
+    /// Retrieves an object in a binary cache by its store path hash.
+    ///
+    /// Unlike `find_object_and_chunks_by_store_path_hash` this touches only
+    /// the object table, for callers that hold a cache ID already and need
+    /// nothing from the NAR.
+    async fn find_object_by_store_path_hash(
+        &self,
+        cache_id: i64,
+        store_path_hash: &StorePathHash,
+    ) -> ServerResult<ObjectModel>;
+
     /// Retrieves a binary cache.
     async fn find_cache(&self, cache: &CacheName) -> ServerResult<CacheModel>;
 
@@ -221,6 +232,20 @@ impl AtticDatabase for DatabaseConnection {
         }
 
         Ok((object, cache, nar, chunks))
+    }
+
+    async fn find_object_by_store_path_hash(
+        &self,
+        cache_id: i64,
+        store_path_hash: &StorePathHash,
+    ) -> ServerResult<ObjectModel> {
+        Object::find()
+            .filter(object::Column::CacheId.eq(cache_id))
+            .filter(object::Column::StorePathHash.eq(store_path_hash.as_str()))
+            .one(self)
+            .await
+            .map_err(ServerError::database_error)?
+            .ok_or_else(|| ErrorKind::NoSuchObject.into())
     }
 
     async fn find_cache(&self, cache: &CacheName) -> ServerResult<CacheModel> {

--- a/server/src/gc.rs
+++ b/server/src/gc.rs
@@ -16,6 +16,7 @@ use tracing::instrument;
 
 use super::{State, StateInner};
 use crate::config::Config;
+use crate::database::entity::build_trace::{self, Entity as BuildTrace};
 use crate::database::entity::cache::{self, Entity as Cache};
 use crate::database::entity::chunk::{self, ChunkState, Entity as Chunk};
 use crate::database::entity::chunkref::{self, Entity as ChunkRef};
@@ -55,6 +56,7 @@ pub async fn run_garbage_collection_once(config: Config) -> Result<()> {
 
     let state = StateInner::new(config).await;
     run_time_based_garbage_collection(&state).await?;
+    run_reap_dangling_build_traces(&state).await?;
     run_reap_orphan_nars(&state).await?;
     run_reap_orphan_chunks(&state).await?;
 
@@ -118,6 +120,41 @@ async fn run_time_based_garbage_collection(state: &State) -> Result<()> {
     }
 
     tracing::info!("Deleted {} objects in total", objects_deleted);
+
+    Ok(())
+}
+
+/// Deletes build traces that no longer resolve to an object in their cache.
+///
+/// Reaping an object leaves its trace behind, advertising a resolution this
+/// cache can no longer satisfy.
+#[instrument(skip_all)]
+async fn run_reap_dangling_build_traces(state: &State) -> Result<()> {
+    let db = state.database().await?;
+
+    // A correlated `NOT EXISTS` lets the planner make one pass over
+    // `build_trace` and probe `object` through its index.
+    let object_for_trace = Query::select()
+        .expr(Expr::val(1))
+        .from(Object)
+        .and_where(
+            object::Column::CacheId
+                .into_expr()
+                .eq(build_trace::Column::CacheId.into_expr()),
+        )
+        .and_where(
+            object::Column::StorePathHash
+                .into_expr()
+                .eq(build_trace::Column::OutPathHash.into_expr()),
+        )
+        .to_owned();
+
+    let deletion = BuildTrace::delete_many()
+        .filter(Expr::exists(object_for_trace).not())
+        .exec(db)
+        .await?;
+
+    tracing::info!("Deleted {} dangling build traces", deletion.rows_affected);
 
     Ok(())
 }


### PR DESCRIPTION
This is an attempt to implement support for pushing and serving build traces. The changes are partially AI-assisted. We're testing the PR in our deployment for now.