### PR TITLE
Fix part checksumming errors

### DIFF
--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -286,10 +286,6 @@ impl StorageBackend for S3Backend {
                 CompletedPart::builder()
                     .set_e_tag(part.e_tag().map(str::to_string))
                     .set_part_number(Some(part_number as i32))
-                    .set_checksum_crc32(part.checksum_crc32().map(str::to_string))
-                    .set_checksum_crc32_c(part.checksum_crc32_c().map(str::to_string))
-                    .set_checksum_sha1(part.checksum_sha1().map(str::to_string))
-                    .set_checksum_sha256(part.checksum_sha256().map(str::to_string))
                     .build()
             })
             .collect::<Vec<_>>();


### PR DESCRIPTION
Mirrors https://github.com/zhaofengli/attic/pull/268
Fixes the bug described in https://github.com/zhaofengli/attic/issues/267, which in my tests still occurred in celler. I’m not sure why this doesn’t show up in the integration test.

Original Title:

> let aws sdk handle checksumming on its own

Original Description:

> I believe the default behavior (what this commit implements) is to not do object-level checksumming and to automatically do per-part checksumming with CRC32.